### PR TITLE
Milvus CLI document updation for TLS support

### DIFF
--- a/site/en/getstarted/run-milvus-docker/prerequisite-docker.md
+++ b/site/en/getstarted/run-milvus-docker/prerequisite-docker.md
@@ -45,7 +45,7 @@ mkdir test-data
 fio --rw=write --ioengine=sync --fdatasync=1 --directory=test-data --size=2200m --bs=2300 --name=mytest
 ```
 
-Ideally, your disk should reach over 500  IOPS and below 10ms for the 99th percentile fsync latency. Read the etcd [Docs](https://etcd.io/docs/v3.5/op-guide/hardware/#disks) for more detailed requirements.
+Ideally, your disk dedicated to etcd should reach over 500  IOPS and below 10ms for the 99th percentile fsync latency. Read the etcd [Docs](https://etcd.io/docs/v3.5/op-guide/hardware/#disks) for more detailed requirements.
 
 ## What's next
 

--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -42,7 +42,7 @@ connect [-uri (text)] [-t (text)] [-tls (0|1|2)] [-cert (text)]
 | :----- | :-------- | :-----------------------------------------------------------------------------------------------------                                 |
 | -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                                                      |
 | -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                                                        |
-| -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). The default is 0. TLS mode 2 is not supported. |
+| -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way), 2 (Two-way, not supported). Default is 0.                                         |
 | -cert  | --cert    | (Optional) Path to the client certificate file. The default is None.                                                                   |
 | --help | n/a       | Displays help for using the command.                                                                                                   |
 

--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -33,7 +33,7 @@ Connects to Milvus.
 <h3 id="connect">Syntax</h3>
 
 ```shell
-connect [-uri (text)] [-t (text)] [-tls (0|1|2)] [-cert (text)]
+connect [-uri (text)] [-t (text)] [-tls (0|1)] [-cert (text)]
 ```
 
 <h3 id="connect">Options</h3>

--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -38,13 +38,13 @@ connect [-uri (text)] [-t (text)] [-tls (0|1|2)] [-cert (text)]
 
 <h3 id="connect">Options</h3>
 
-| Option | Full name | Description                                                                                              |
-| :----- | :-------- | :-----------------------------------------------------------------------------------------------------   |
-| -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                        |
-| -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                          |
-| -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). The default is 0 |
-| -cert  | --cert    | (Optional) Path to the client certificate file. The default is None.                                     |
-| --help | n/a       | Displays help for using the command.                                                                     |
+| Option | Full name | Description                                                                                                                            |
+| :----- | :-------- | :-----------------------------------------------------------------------------------------------------                                 |
+| -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                                                      |
+| -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                                                        |
+| -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). The default is 0. TLS mode 2 is not supported. |
+| -cert  | --cert    | (Optional) Path to the client certificate file. The default is None.                                                                   |
+| --help | n/a       | Displays help for using the command.                                                                                                   |
 
 <h3 id="connect">Example</h3>
 

--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -33,7 +33,7 @@ Connects to Milvus.
 <h3 id="connect">Syntax</h3>
 
 ```shell
-connect [-uri (text)] [-t (text)] [--tlsmode (0|1|2)] [--cert (text)]
+connect [-uri (text)] [-t (text)] [-tls (0|1|2)] [-cert (text)]
 ```
 
 <h3 id="connect">Options</h3>
@@ -43,7 +43,7 @@ connect [-uri (text)] [-t (text)] [--tlsmode (0|1|2)] [--cert (text)]
 | -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                        |
 | -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                          |
 | -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). The default is 0 |
-| -t     | --token   | (Optional) Path to the client certificate file. The default is None.                                     |
+| -cert  | --cert    | (Optional) Path to the client certificate file. The default is None.                                     |
 | --help | n/a       | Displays help for using the command.                                                                     |
 
 <h3 id="connect">Example</h3>

--- a/site/en/userGuide/tools/cli_commands.md
+++ b/site/en/userGuide/tools/cli_commands.md
@@ -33,21 +33,23 @@ Connects to Milvus.
 <h3 id="connect">Syntax</h3>
 
 ```shell
-connect [-uri (text)] [-t (text)]
+connect [-uri (text)] [-t (text)] [--tlsmode (0|1|2)] [--cert (text)]
 ```
 
 <h3 id="connect">Options</h3>
 
-| Option | Full name | Description                                                                     |
-| :----- | :-------- | :------------------------------------------------------------------------------ |
-| -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".               |
-| -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None. |
-| --help | n/a       | Displays help for using the command.                                            |
+| Option | Full name | Description                                                                                              |
+| :----- | :-------- | :-----------------------------------------------------------------------------------------------------   |
+| -uri   | --uri     | (Optional) The uri name. The default is "http://127.0.0.1:19530".                                        |
+| -t     | --token   | (Optional) The zilliz cloud apikey or `username:password`. The default is None.                          |
+| -tls   | --tlsmode | (Optional) TLS mode: 0 (No encryption), 1 (One-way encryption), 2 (Two-way encryption). The default is 0 |
+| -t     | --token   | (Optional) Path to the client certificate file. The default is None.                                     |
+| --help | n/a       | Displays help for using the command.                                                                     |
 
 <h3 id="connect">Example</h3>
 
 ```shell
-milvus_cli > connect -uri http://127.0.0.1:19530
+milvus_cli > connect -uri http://127.0.0.1:19530 -t user:password -tls 0 -cert path/to/file
 ```
 
 ## create Database


### PR DESCRIPTION
As part of https://github.com/zilliztech/milvus_cli/pull/100, Milvus CLI now supports TLS authentication with certificates and it need to be documented